### PR TITLE
feat: add key transformation method for sharding

### DIFF
--- a/plugin/s3ds.go
+++ b/plugin/s3ds.go
@@ -98,11 +98,15 @@ func (s3p S3Plugin) DatastoreConfigParser() fsrepo.ConfigFromMap {
 			}
 		}
 
-		var keySuffix string
-		if v, ok := m["keySuffix"]; ok {
-			keySuffix, ok = v.(string)
-			if !ok {
-				return nil, fmt.Errorf("s3ds: keySuffix not a string")
+		var keyTransform s3ds.KeyTransform
+		if v, ok := m["keyTransform"]; ok {
+			if v == "" {
+				keyTransform = "default"
+			} else {
+				keyTransform, ok = v.(s3ds.KeyTransform)
+				if !ok {
+					return nil, fmt.Errorf("s3ds: keyTransform is not a valid key transform method")
+				}
 			}
 		}
 
@@ -117,7 +121,7 @@ func (s3p S3Plugin) DatastoreConfigParser() fsrepo.ConfigFromMap {
 				Workers:             workers,
 				RegionEndpoint:      endpoint,
 				CredentialsEndpoint: credentialsEndpoint,
-				KeySuffix:           keySuffix,
+				KeyTransform:        keyTransform,
 			},
 		}, nil
 	}

--- a/s3.go
+++ b/s3.go
@@ -53,7 +53,28 @@ type Config struct {
 	RootDirectory       string
 	Workers             int
 	CredentialsEndpoint string
-	KeySuffix           string
+	KeyTransform        KeyTransform
+}
+
+type KeyTransform string
+
+const (
+	Default     KeyTransform = "default"
+	Suffix                   = "suffix"
+	NextToLast2              = "next-to-last/2"
+)
+
+var KeyTransforms = map[KeyTransform]func(ds.Key) string{
+	Default: func(k ds.Key) string {
+		return k.String()
+	},
+	Suffix: func(k ds.Key) string {
+		return k.String() + "/data"
+	},
+	NextToLast2: func(k ds.Key) string {
+		s := k.String()
+		return s[len(s)-2:] + "/" + s
+	},
 }
 
 func NewS3Datastore(conf Config) (*S3Bucket, error) {
@@ -106,7 +127,7 @@ func NewS3Datastore(conf Config) (*S3Bucket, error) {
 func (s *S3Bucket) Put(k ds.Key, value []byte) error {
 	_, err := s.S3.PutObject(&s3.PutObjectInput{
 		Bucket: aws.String(s.Bucket),
-		Key:    aws.String(s.s3Path(k.String() + s.Config.KeySuffix)),
+		Key:    aws.String(s.s3Path(prepareKey(s.Config, k))),
 		Body:   bytes.NewReader(value),
 	})
 	return err
@@ -119,7 +140,7 @@ func (s *S3Bucket) Sync(prefix ds.Key) error {
 func (s *S3Bucket) Get(k ds.Key) ([]byte, error) {
 	resp, err := s.S3.GetObject(&s3.GetObjectInput{
 		Bucket: aws.String(s.Bucket),
-		Key:    aws.String(s.s3Path(k.String() + s.Config.KeySuffix)),
+		Key:    aws.String(s.s3Path(prepareKey(s.Config, k))),
 	})
 	if err != nil {
 		if isNotFound(err) {
@@ -146,7 +167,7 @@ func (s *S3Bucket) Has(k ds.Key) (exists bool, err error) {
 func (s *S3Bucket) GetSize(k ds.Key) (size int, err error) {
 	resp, err := s.S3.HeadObject(&s3.HeadObjectInput{
 		Bucket: aws.String(s.Bucket),
-		Key:    aws.String(s.s3Path(k.String() + s.Config.KeySuffix)),
+		Key:    aws.String(s.s3Path(prepareKey(s.Config, k))),
 	})
 	if err != nil {
 		if s3Err, ok := err.(awserr.Error); ok && s3Err.Code() == "NotFound" {
@@ -160,13 +181,17 @@ func (s *S3Bucket) GetSize(k ds.Key) (size int, err error) {
 func (s *S3Bucket) Delete(k ds.Key) error {
 	_, err := s.S3.DeleteObject(&s3.DeleteObjectInput{
 		Bucket: aws.String(s.Bucket),
-		Key:    aws.String(s.s3Path(k.String() + s.Config.KeySuffix)),
+		Key:    aws.String(s.s3Path(prepareKey(s.Config, k))),
 	})
 	if isNotFound(err) {
 		// delete is idempotent
 		err = nil
 	}
 	return err
+}
+
+func prepareKey(cfg Config, k ds.Key) string {
+	return KeyTransforms[cfg.KeyTransform](k)
 }
 
 func (s *S3Bucket) Query(q dsq.Query) (dsq.Results, error) {

--- a/s3.go
+++ b/s3.go
@@ -73,7 +73,9 @@ var KeyTransforms = map[KeyTransform]func(ds.Key) string{
 	},
 	NextToLast2: func(k ds.Key) string {
 		s := k.String()
-		return s[len(s)-2:] + "/" + s
+		offset := 1
+		start := len(s) - 2 - offset
+		return s[start:start+2] + "/" + s
 	},
 }
 


### PR DESCRIPTION
### Motivation
To get sharding merged into the existing go-ds-s3 plugin. See https://github.com/ipfs/go-ds-s3/pull/195#issuecomment-900466233

### Changes
Instead of just sharding with an S3 key `<cid>/data`, I added a key transforms map that would allow developers to add their own sharding methods.

### Notes
For context, here are the S3 sharding methods available in js-ipfs https://github.com/ipfs/go-ipfs/blob/master/docs/datastores.md#flatfs