### PR TITLE
feat: add sharding for parity with flatfs

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ The config file should include the following:
             "rootDirectory": "$bucketsubdirectory",
             "accessKey": "",
             "secretKey": "",
-            "keyTransform": "$keytransformmethod"
+            "shardFunc": "$shardfunc"
           },
           "mountpoint": "/blocks",
           "prefix": "s3.datastore",
@@ -83,16 +83,19 @@ The config file should include the following:
 
 If the access and secret key are blank they will be loaded from the usual ~/.aws/.
 
-The key transform allows you to specify how data is stored behind S3 keys. It must be one of the available methods:
+The shard function allows you to specify how data is stored behind S3 keys. It must be one of the available methods:
 
-`default`
+`/repo/s3/shard/v1/identity/0`
 - No sharding.
 
-`suffix`
-- Shards by storing block data at a key with a `data` suffix. E.g. `CIQJ7IHPGOFUJT5UMXIW6CUDSNH6AVKMEOXI3UM3VLYJRZUISUMGCXQ/data`
+`/repo/s3/shard/v1/prefix/<n>`
+- Shards by storing block data at a key with the n first characters of its CID. E.g. `CIQJ7IHP/CIQJ7IHPGOFUJT5UMXIW6CUDSNH6AVKMEOXI3UM3VLYJRZUISUMGCXQ`
 
-`next-to-last/2`
-- Shards by storing block data based on the second to last 2 characters of its key. E.g. `CX/CIQJ7IHPGOFUJT5UMXIW6CUDSNH6AVKMEOXI3UM3VLYJRZUISUMGCXQ`
+`/repo/s3/shard/v1/suffix/<n>`
+- Shards by storing block data at a key with the n last characters of its CID. E.g. `CXQ/CIQJ7IHPGOFUJT5UMXIW6CUDSNH6AVKMEOXI3UM3VLYJRZUISUMGCXQ`
+
+`/repo/s3/shard/v1/next-to-last/<n>`
+- Shards by storing block data at a key with the second to last n characters of its CID. E.g. `CX/CIQJ7IHPGOFUJT5UMXIW6CUDSNH6AVKMEOXI3UM3VLYJRZUISUMGCXQ`
 
 If you are on another S3 compatible provider, e.g. Linode, then your config should be:
 
@@ -112,7 +115,7 @@ If you are on another S3 compatible provider, e.g. Linode, then your config shou
             "regionEndpoint": "us-east-1.linodeobjects.com",
             "accessKey": "",
             "secretKey": "",
-            "keyTransform": "$keytransformmethod"
+            "shardFunc": "$shardfunc"
           },
           "mountpoint": "/blocks",
           "prefix": "s3.datastore",
@@ -137,7 +140,9 @@ This repository falls under the IPFS [Code of Conduct](https://github.com/ipfs/c
 ### Local Development
 
 ```
+go install
 go mod vendor
+go test
 ```
 
 ### Want to hack on IPFS?

--- a/plugin/s3ds.go
+++ b/plugin/s3ds.go
@@ -98,14 +98,14 @@ func (s3p S3Plugin) DatastoreConfigParser() fsrepo.ConfigFromMap {
 			}
 		}
 
-		var keyTransform string
-		if v, ok := m["keyTransform"]; ok {
+		var shardFunc string
+		if v, ok := m["shardFunc"]; ok {
 			if v == "" {
-				keyTransform = "default"
+				shardFunc = "/repo/s3/shard/v1/identity/0"
 			} else {
-				keyTransform, ok = v.(string)
+				shardFunc, ok = v.(string)
 				if !ok {
-					return nil, fmt.Errorf("s3ds: keyTransform is not a valid key transform method")
+					return nil, fmt.Errorf("s3ds: shardFunc is not a valid string")
 				}
 			}
 		}
@@ -121,7 +121,7 @@ func (s3p S3Plugin) DatastoreConfigParser() fsrepo.ConfigFromMap {
 				Workers:             workers,
 				RegionEndpoint:      endpoint,
 				CredentialsEndpoint: credentialsEndpoint,
-				KeyTransform:        keyTransform,
+				ShardFunc:           shardFunc,
 			},
 		}, nil
 	}

--- a/plugin/s3ds_test.go
+++ b/plugin/s3ds_test.go
@@ -47,7 +47,7 @@ func TestS3PluginDatastoreConfigParser(t *testing.T) {
 				"regionEndpoint":      "someendpoint",
 				"workers":             42.0,
 				"credentialsEndpoint": "somecredendpoint",
-				"keyTransform":        "default",
+				"shardFunc":           "/repo/s3/shard/v1/next-to-last/2",
 			},
 			Want: &S3Config{cfg: s3ds.Config{
 				Region:              "someregion",
@@ -59,7 +59,7 @@ func TestS3PluginDatastoreConfigParser(t *testing.T) {
 				RegionEndpoint:      "someendpoint",
 				Workers:             42,
 				CredentialsEndpoint: "somecredendpoint",
-				KeyTransform:        "default",
+				ShardFunc:           "/repo/s3/shard/v1/next-to-last/2",
 			}},
 		},
 	}

--- a/s3_test.go
+++ b/s3_test.go
@@ -19,9 +19,9 @@ func TestSuiteLocalS3(t *testing.T) {
 		t.Skipf("skipping test suit; LOCAL_S3 is not set.")
 	}
 
-  localBucketName, localBucketNameSet := os.LookupEnv("LOCAL_BUCKET_NAME")
-  if !localBucketNameSet {
-    localBucketName = fmt.Sprintf("localbucketname%d", time.Now().UnixNano())
+	localBucketName, localBucketNameSet := os.LookupEnv("LOCAL_BUCKET_NAME")
+	if !localBucketNameSet {
+		localBucketName = fmt.Sprintf("localbucketname%d", time.Now().UnixNano())
 	}
 
 	config := Config{
@@ -30,7 +30,7 @@ func TestSuiteLocalS3(t *testing.T) {
 		Region:         "local",
 		AccessKey:      "test",
 		SecretKey:      "testdslocal",
-		KeyTransform:   "default",
+		ShardFunc:      "/repo/s3/shard/v1/identity/0",
 	}
 
 	s3ds, err := NewS3Datastore(config)

--- a/shard.go
+++ b/shard.go
@@ -36,7 +36,7 @@ func Identity() *ShardIdV1 {
 		funName: "identity",
 		param:   0,
 		fun: func(noslash string) string {
-			return noslash
+			return ""
 		},
 	}
 }

--- a/shard.go
+++ b/shard.go
@@ -1,0 +1,123 @@
+package s3ds
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+var IPFS_DEF_SHARD = NextToLast(2)
+var IPFS_DEF_SHARD_STR = IPFS_DEF_SHARD.String()
+
+const PREFIX = "/repo/s3/shard/"
+
+// TODO: Read existing sharding method
+// const SHARDING_FN = "SHARDING"
+// const README_FN = "_README"
+
+type ShardFunc func(string) string
+
+type ShardIdV1 struct {
+	funName string
+	param   int
+	fun     ShardFunc
+}
+
+func (f *ShardIdV1) String() string {
+	return fmt.Sprintf("%sv1/%s/%d", PREFIX, f.funName, f.param)
+}
+
+func (f *ShardIdV1) Func() ShardFunc {
+	return f.fun
+}
+
+func Identity() *ShardIdV1 {
+	return &ShardIdV1{
+		funName: "identity",
+		param:   0,
+		fun: func(noslash string) string {
+			return noslash
+		},
+	}
+}
+
+func Prefix(prefixLen int) *ShardIdV1 {
+	padding := strings.Repeat("_", prefixLen)
+	return &ShardIdV1{
+		funName: "prefix",
+		param:   prefixLen,
+		fun: func(noslash string) string {
+			return (noslash + padding)[:prefixLen]
+		},
+	}
+}
+
+func Suffix(suffixLen int) *ShardIdV1 {
+	padding := strings.Repeat("_", suffixLen)
+	return &ShardIdV1{
+		funName: "suffix",
+		param:   suffixLen,
+		fun: func(noslash string) string {
+			str := padding + noslash
+			return str[len(str)-suffixLen:]
+		},
+	}
+}
+
+func NextToLast(suffixLen int) *ShardIdV1 {
+	padding := strings.Repeat("_", suffixLen+1)
+	return &ShardIdV1{
+		funName: "next-to-last",
+		param:   suffixLen,
+		fun: func(noslash string) string {
+			str := padding + noslash
+			offset := len(str) - suffixLen - 1
+			return str[offset : offset+suffixLen]
+		},
+	}
+}
+
+func ParseShardFunc(str string) (*ShardIdV1, error) {
+	str = strings.TrimSpace(str)
+
+	if len(str) == 0 {
+		return nil, fmt.Errorf("empty shard identifier")
+	}
+
+	trimmed := strings.TrimPrefix(str, PREFIX)
+	if str == trimmed { // nothing trimmed
+		return nil, fmt.Errorf("invalid or no prefix in shard identifier: %s", str)
+	}
+	str = trimmed
+
+	parts := strings.Split(str, "/")
+	if len(parts) != 3 {
+		return nil, fmt.Errorf("invalid shard identifier: %s", str)
+	}
+
+	version := parts[0]
+	if version != "v1" {
+		return nil, fmt.Errorf("expected 'v1' for version string got: %s", version)
+	}
+
+	funName := parts[1]
+
+	param, err := strconv.Atoi(parts[2])
+	if err != nil {
+		return nil, fmt.Errorf("invalid parameter: %v", err)
+	}
+
+	switch funName {
+	case "identity":
+		return Identity(), nil
+	case "prefix":
+		return Prefix(param), nil
+	case "suffix":
+		return Suffix(param), nil
+	case "next-to-last":
+		return NextToLast(param), nil
+	default:
+		return nil, fmt.Errorf("expected 'identity', 'prefix', 'suffix' or 'next-to-last' got: %s", funName)
+	}
+
+}

--- a/shard_test.go
+++ b/shard_test.go
@@ -11,37 +11,37 @@ func TestIdentity(t *testing.T) {
 	cases := []struct {
 		shardFunc string
 		cid       string
-		s3Key     string
+		s3Dir     string
 	}{
 		{
 			shardFunc: "/repo/s3/shard/v1/identity/0",
 			cid:       "a",
-			s3Key:     "a",
+			s3Dir:     "",
 		},
 		{
 			shardFunc: "/repo/s3/shard/v1/identity/1",
 			cid:       "a",
-			s3Key:     "a",
+			s3Dir:     "",
 		},
 		{
 			shardFunc: "/repo/s3/shard/v1/identity/2",
 			cid:       "ab",
-			s3Key:     "ab",
+			s3Dir:     "",
 		},
 		{
 			shardFunc: "/repo/s3/shard/v1/identity/1",
 			cid:       "abc",
-			s3Key:     "abc",
+			s3Dir:     "",
 		},
 		{
 			shardFunc: "/repo/s3/shard/v1/identity/0",
 			cid:       "abcd",
-			s3Key:     "abcd",
+			s3Dir:     "",
 		},
 		{
 			shardFunc: "/repo/s3/shard/v1/identity/100000000",
 			cid:       "CIQJ7IHPGOFUJT5UMXIW6CUDSNH6AVKMEOXI3UM3VLYJRZUISUMGCXQ",
-			s3Key:     "CIQJ7IHPGOFUJT5UMXIW6CUDSNH6AVKMEOXI3UM3VLYJRZUISUMGCXQ",
+			s3Dir:     "",
 		},
 	}
 	for _, c := range cases {
@@ -53,9 +53,9 @@ func TestIdentity(t *testing.T) {
 
 			k := ds.NewKey(c.cid)
 			noslash := k.String()[1:]
-			s3Key := id.fun(noslash)
-			if s3Key != c.s3Key {
-				t.Fatalf("expected %s, got %s", c.s3Key, s3Key)
+			s3Dir := id.fun(noslash)
+			if s3Dir != c.s3Dir {
+				t.Fatalf("expected %s, got %s", c.s3Dir, s3Dir)
 			}
 		})
 	}
@@ -65,37 +65,37 @@ func TestPrefix(t *testing.T) {
 	cases := []struct {
 		shardFunc string
 		cid       string
-		s3Key     string
+		s3Dir     string
 	}{
 		{
 			shardFunc: "/repo/s3/shard/v1/prefix/2",
 			cid:       "a",
-			s3Key:     "a_",
+			s3Dir:     "a_",
 		},
 		{
 			shardFunc: "/repo/s3/shard/v1/prefix/2",
 			cid:       "ab",
-			s3Key:     "ab",
+			s3Dir:     "ab",
 		},
 		{
 			shardFunc: "/repo/s3/shard/v1/prefix/2",
 			cid:       "abc",
-			s3Key:     "ab",
+			s3Dir:     "ab",
 		},
 		{
 			shardFunc: "/repo/s3/shard/v1/prefix/2",
 			cid:       "abcd",
-			s3Key:     "ab",
+			s3Dir:     "ab",
 		},
 		{
 			shardFunc: "/repo/s3/shard/v1/prefix/3",
 			cid:       "CIQJ7IHPGOFUJT5UMXIW6CUDSNH6AVKMEOXI3UM3VLYJRZUISUMGCXQ",
-			s3Key:     "CIQ",
+			s3Dir:     "CIQ",
 		},
 		{
 			shardFunc: "/repo/s3/shard/v1/prefix/8",
 			cid:       "CIQJ7IHPGOFUJT5UMXIW6CUDSNH6AVKMEOXI3UM3VLYJRZUISUMGCXQ",
-			s3Key:     "CIQJ7IHP",
+			s3Dir:     "CIQJ7IHP",
 		},
 	}
 	for _, c := range cases {
@@ -107,9 +107,9 @@ func TestPrefix(t *testing.T) {
 
 			k := ds.NewKey(c.cid)
 			noslash := k.String()[1:]
-			s3Key := id.fun(noslash)
-			if s3Key != c.s3Key {
-				t.Fatalf("expected %s, got %s", c.s3Key, s3Key)
+			s3Dir := id.fun(noslash)
+			if s3Dir != c.s3Dir {
+				t.Fatalf("expected %s, got %s", c.s3Dir, s3Dir)
 			}
 		})
 	}
@@ -119,37 +119,37 @@ func TestSuffix(t *testing.T) {
 	cases := []struct {
 		shardFunc string
 		cid       string
-		s3Key     string
+		s3Dir     string
 	}{
 		{
 			shardFunc: "/repo/s3/shard/v1/suffix/2",
 			cid:       "a",
-			s3Key:     "_a",
+			s3Dir:     "_a",
 		},
 		{
 			shardFunc: "/repo/s3/shard/v1/suffix/2",
 			cid:       "ab",
-			s3Key:     "ab",
+			s3Dir:     "ab",
 		},
 		{
 			shardFunc: "/repo/s3/shard/v1/suffix/2",
 			cid:       "abc",
-			s3Key:     "bc",
+			s3Dir:     "bc",
 		},
 		{
 			shardFunc: "/repo/s3/shard/v1/suffix/2",
 			cid:       "abcd",
-			s3Key:     "cd",
+			s3Dir:     "cd",
 		},
 		{
 			shardFunc: "/repo/s3/shard/v1/suffix/3",
 			cid:       "CIQJ7IHPGOFUJT5UMXIW6CUDSNH6AVKMEOXI3UM3VLYJRZUISUMGCXQ",
-			s3Key:     "CXQ",
+			s3Dir:     "CXQ",
 		},
 		{
 			shardFunc: "/repo/s3/shard/v1/suffix/8",
 			cid:       "CIQJ7IHPGOFUJT5UMXIW6CUDSNH6AVKMEOXI3UM3VLYJRZUISUMGCXQ",
-			s3Key:     "ISUMGCXQ",
+			s3Dir:     "ISUMGCXQ",
 		},
 	}
 	for _, c := range cases {
@@ -161,9 +161,9 @@ func TestSuffix(t *testing.T) {
 
 			k := ds.NewKey(c.cid)
 			noslash := k.String()[1:]
-			s3Key := id.fun(noslash)
-			if s3Key != c.s3Key {
-				t.Fatalf("expected %s, got %s", c.s3Key, s3Key)
+			s3Dir := id.fun(noslash)
+			if s3Dir != c.s3Dir {
+				t.Fatalf("expected %s, got %s", c.s3Dir, s3Dir)
 			}
 		})
 	}
@@ -173,37 +173,37 @@ func TestNextToLast(t *testing.T) {
 	cases := []struct {
 		shardFunc string
 		cid       string
-		s3Key     string
+		s3Dir     string
 	}{
 		{
 			shardFunc: "/repo/s3/shard/v1/next-to-last/2",
 			cid:       "a",
-			s3Key:     "__",
+			s3Dir:     "__",
 		},
 		{
 			shardFunc: "/repo/s3/shard/v1/next-to-last/2",
 			cid:       "ab",
-			s3Key:     "_a",
+			s3Dir:     "_a",
 		},
 		{
 			shardFunc: "/repo/s3/shard/v1/next-to-last/2",
 			cid:       "abc",
-			s3Key:     "ab",
+			s3Dir:     "ab",
 		},
 		{
 			shardFunc: "/repo/s3/shard/v1/next-to-last/2",
 			cid:       "abcd",
-			s3Key:     "bc",
+			s3Dir:     "bc",
 		},
 		{
 			shardFunc: "/repo/s3/shard/v1/next-to-last/3",
 			cid:       "CIQJ7IHPGOFUJT5UMXIW6CUDSNH6AVKMEOXI3UM3VLYJRZUISUMGCXQ",
-			s3Key:     "GCX",
+			s3Dir:     "GCX",
 		},
 		{
 			shardFunc: "/repo/s3/shard/v1/next-to-last/8",
 			cid:       "CIQJ7IHPGOFUJT5UMXIW6CUDSNH6AVKMEOXI3UM3VLYJRZUISUMGCXQ",
-			s3Key:     "UISUMGCX",
+			s3Dir:     "UISUMGCX",
 		},
 	}
 	for _, c := range cases {
@@ -215,9 +215,9 @@ func TestNextToLast(t *testing.T) {
 
 			k := ds.NewKey(c.cid)
 			noslash := k.String()[1:]
-			s3Key := id.fun(noslash)
-			if s3Key != c.s3Key {
-				t.Fatalf("expected %s, got %s", c.s3Key, s3Key)
+			s3Dir := id.fun(noslash)
+			if s3Dir != c.s3Dir {
+				t.Fatalf("expected %s, got %s", c.s3Dir, s3Dir)
 			}
 		})
 	}

--- a/shard_test.go
+++ b/shard_test.go
@@ -1,0 +1,224 @@
+package s3ds
+
+import (
+	"fmt"
+	"testing"
+
+	ds "github.com/ipfs/go-datastore"
+)
+
+func TestIdentity(t *testing.T) {
+	cases := []struct {
+		shardFunc string
+		cid       string
+		s3Key     string
+	}{
+		{
+			shardFunc: "/repo/s3/shard/v1/identity/0",
+			cid:       "a",
+			s3Key:     "a",
+		},
+		{
+			shardFunc: "/repo/s3/shard/v1/identity/1",
+			cid:       "a",
+			s3Key:     "a",
+		},
+		{
+			shardFunc: "/repo/s3/shard/v1/identity/2",
+			cid:       "ab",
+			s3Key:     "ab",
+		},
+		{
+			shardFunc: "/repo/s3/shard/v1/identity/1",
+			cid:       "abc",
+			s3Key:     "abc",
+		},
+		{
+			shardFunc: "/repo/s3/shard/v1/identity/0",
+			cid:       "abcd",
+			s3Key:     "abcd",
+		},
+		{
+			shardFunc: "/repo/s3/shard/v1/identity/100000000",
+			cid:       "CIQJ7IHPGOFUJT5UMXIW6CUDSNH6AVKMEOXI3UM3VLYJRZUISUMGCXQ",
+			s3Key:     "CIQJ7IHPGOFUJT5UMXIW6CUDSNH6AVKMEOXI3UM3VLYJRZUISUMGCXQ",
+		},
+	}
+	for _, c := range cases {
+		t.Run(fmt.Sprintf("%s %s", c.shardFunc, c.cid), func(t *testing.T) {
+			id, parseErr := ParseShardFunc(c.shardFunc)
+			if parseErr != nil {
+				t.Fatalf(parseErr.Error())
+			}
+
+			k := ds.NewKey(c.cid)
+			noslash := k.String()[1:]
+			s3Key := id.fun(noslash)
+			if s3Key != c.s3Key {
+				t.Fatalf("expected %s, got %s", c.s3Key, s3Key)
+			}
+		})
+	}
+}
+
+func TestPrefix(t *testing.T) {
+	cases := []struct {
+		shardFunc string
+		cid       string
+		s3Key     string
+	}{
+		{
+			shardFunc: "/repo/s3/shard/v1/prefix/2",
+			cid:       "a",
+			s3Key:     "a_",
+		},
+		{
+			shardFunc: "/repo/s3/shard/v1/prefix/2",
+			cid:       "ab",
+			s3Key:     "ab",
+		},
+		{
+			shardFunc: "/repo/s3/shard/v1/prefix/2",
+			cid:       "abc",
+			s3Key:     "ab",
+		},
+		{
+			shardFunc: "/repo/s3/shard/v1/prefix/2",
+			cid:       "abcd",
+			s3Key:     "ab",
+		},
+		{
+			shardFunc: "/repo/s3/shard/v1/prefix/3",
+			cid:       "CIQJ7IHPGOFUJT5UMXIW6CUDSNH6AVKMEOXI3UM3VLYJRZUISUMGCXQ",
+			s3Key:     "CIQ",
+		},
+		{
+			shardFunc: "/repo/s3/shard/v1/prefix/8",
+			cid:       "CIQJ7IHPGOFUJT5UMXIW6CUDSNH6AVKMEOXI3UM3VLYJRZUISUMGCXQ",
+			s3Key:     "CIQJ7IHP",
+		},
+	}
+	for _, c := range cases {
+		t.Run(fmt.Sprintf("%s %s", c.shardFunc, c.cid), func(t *testing.T) {
+			id, parseErr := ParseShardFunc(c.shardFunc)
+			if parseErr != nil {
+				t.Fatalf(parseErr.Error())
+			}
+
+			k := ds.NewKey(c.cid)
+			noslash := k.String()[1:]
+			s3Key := id.fun(noslash)
+			if s3Key != c.s3Key {
+				t.Fatalf("expected %s, got %s", c.s3Key, s3Key)
+			}
+		})
+	}
+}
+
+func TestSuffix(t *testing.T) {
+	cases := []struct {
+		shardFunc string
+		cid       string
+		s3Key     string
+	}{
+		{
+			shardFunc: "/repo/s3/shard/v1/suffix/2",
+			cid:       "a",
+			s3Key:     "_a",
+		},
+		{
+			shardFunc: "/repo/s3/shard/v1/suffix/2",
+			cid:       "ab",
+			s3Key:     "ab",
+		},
+		{
+			shardFunc: "/repo/s3/shard/v1/suffix/2",
+			cid:       "abc",
+			s3Key:     "bc",
+		},
+		{
+			shardFunc: "/repo/s3/shard/v1/suffix/2",
+			cid:       "abcd",
+			s3Key:     "cd",
+		},
+		{
+			shardFunc: "/repo/s3/shard/v1/suffix/3",
+			cid:       "CIQJ7IHPGOFUJT5UMXIW6CUDSNH6AVKMEOXI3UM3VLYJRZUISUMGCXQ",
+			s3Key:     "CXQ",
+		},
+		{
+			shardFunc: "/repo/s3/shard/v1/suffix/8",
+			cid:       "CIQJ7IHPGOFUJT5UMXIW6CUDSNH6AVKMEOXI3UM3VLYJRZUISUMGCXQ",
+			s3Key:     "ISUMGCXQ",
+		},
+	}
+	for _, c := range cases {
+		t.Run(fmt.Sprintf("%s %s", c.shardFunc, c.cid), func(t *testing.T) {
+			id, parseErr := ParseShardFunc(c.shardFunc)
+			if parseErr != nil {
+				t.Fatalf(parseErr.Error())
+			}
+
+			k := ds.NewKey(c.cid)
+			noslash := k.String()[1:]
+			s3Key := id.fun(noslash)
+			if s3Key != c.s3Key {
+				t.Fatalf("expected %s, got %s", c.s3Key, s3Key)
+			}
+		})
+	}
+}
+
+func TestNextToLast(t *testing.T) {
+	cases := []struct {
+		shardFunc string
+		cid       string
+		s3Key     string
+	}{
+		{
+			shardFunc: "/repo/s3/shard/v1/next-to-last/2",
+			cid:       "a",
+			s3Key:     "__",
+		},
+		{
+			shardFunc: "/repo/s3/shard/v1/next-to-last/2",
+			cid:       "ab",
+			s3Key:     "_a",
+		},
+		{
+			shardFunc: "/repo/s3/shard/v1/next-to-last/2",
+			cid:       "abc",
+			s3Key:     "ab",
+		},
+		{
+			shardFunc: "/repo/s3/shard/v1/next-to-last/2",
+			cid:       "abcd",
+			s3Key:     "bc",
+		},
+		{
+			shardFunc: "/repo/s3/shard/v1/next-to-last/3",
+			cid:       "CIQJ7IHPGOFUJT5UMXIW6CUDSNH6AVKMEOXI3UM3VLYJRZUISUMGCXQ",
+			s3Key:     "GCX",
+		},
+		{
+			shardFunc: "/repo/s3/shard/v1/next-to-last/8",
+			cid:       "CIQJ7IHPGOFUJT5UMXIW6CUDSNH6AVKMEOXI3UM3VLYJRZUISUMGCXQ",
+			s3Key:     "UISUMGCX",
+		},
+	}
+	for _, c := range cases {
+		t.Run(fmt.Sprintf("%s %s", c.shardFunc, c.cid), func(t *testing.T) {
+			id, parseErr := ParseShardFunc(c.shardFunc)
+			if parseErr != nil {
+				t.Fatalf(parseErr.Error())
+			}
+
+			k := ds.NewKey(c.cid)
+			noslash := k.String()[1:]
+			s3Key := id.fun(noslash)
+			if s3Key != c.s3Key {
+				t.Fatalf("expected %s, got %s", c.s3Key, s3Key)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Adds more sharding methods for parity with [go-ds-flatfs](https://github.com/ipfs/go-ds-flatfs/blob/master/shard.go) methods and also compatibility with [js-datastore](https://github.com/ipfs/js-datastore-core/blob/master/src/shard.js)